### PR TITLE
docs: add project CONTEXT.md and supporting research docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,176 @@
+# DiffGraph-CLI — Project Context
+
+> **Read this before working on anything in this project.**
+
+---
+
+## The North Star
+
+> *WildestAI turns code changes from raw diffs into understandable, evidence-linked software evolution.*
+
+**The durable triad — always return to this:**
+1. **What changed?** (not just lines/files — components, behavior, APIs, dependencies)
+2. **Why did it change?** (intent, prompt, decision, constraint, alternative considered)
+3. **What is the impact?** (runtime behavior, risk, test coverage, architectural drift, future agents)
+
+Everything else — CLI, VS Code, GitHub, Vibinex, graphs, dashboards — is a surface in service of this triad.
+
+---
+
+## The Problem We're Solving
+
+AI has made code *generation* cheap. Verification is now the bottleneck.
+
+The METR 2025 study (see `docs/research/METR-2025-summary.md`) found that experienced developers with AI tools were **19% slower**, not faster — on large, mature codebases they knew well. The cause: low AI reliability, wasted time reviewing AI outputs, and a mismatch between perceived and actual productivity gains.
+
+Avikalp's personal experience: the more he uses AI to write code, the more he needs a better way to quickly understand and review what changed. That's the wedge this project exists to address.
+
+**The core insight:**
+- Reading a diff ≠ understanding a change
+- Understanding a change ≠ verifying it should exist
+- Traditional diffs worked when humans wrote small, deliberate changes; they break when AI generates thousands of lines in minutes
+
+**AI mistakes are distinct from human mistakes.** AI agents:
+- Overfit to the prompt
+- Miss unstated architectural constraints
+- Modify files outside intended scope
+- Satisfy visible tests while missing hidden invariants
+- Hallucinate APIs, conventions, or behavior
+- Don't carry organizational memory
+
+WildestAI should be designed around this new failure profile, not around recreating human code review with AI summaries.
+
+---
+
+## What This Project Is Not
+
+- Not "AI PR summary" (that's a commodity feature, not a product)
+- Not a pretty graph generator that sacrifices correctness for visual flair
+- Not a thin wrapper over one LLM
+- Not locked to any single surface (CLI, VS Code, GitHub)
+- Not a replacement for developer judgment — a reduction of the *work required* to exercise it
+
+**Red line:** Every claim should be traceable to evidence (code, metadata, test). No "vibes" outputs.
+
+---
+
+## Product Surfaces (History + Direction)
+
+| Surface | Status | Purpose |
+|---------|--------|---------|
+| `wild` CLI | ✅ v1.0 built | Engine + local entry point; `wild diff` → DiffGraph |
+| VS Code extension | 🔄 planned | Inner-loop: "what did this agent just do?" |
+| Vibinex / GitHub extension | 🔄 planned | Middle-loop: PR review, semantic navigation |
+| CI/CD integration | 🔜 future | Automated artifacts, risk flagging |
+| Enterprise / on-prem | 🔜 future | Compliance, traceability, audit |
+| Agent-facing layer | 🔜 future | Structured context for other AI agents |
+
+**Current focus:** Make `wild diff` and the VS Code extension extremely useful for understanding AI-generated local changes, while designing the core representation to power everything else later.
+
+---
+
+## Current CLI State (as of May 2026)
+
+The `wild` CLI (`diffgraph/`) is at **v1.0**. It:
+- Wraps `git` — passes all non-diff commands through to `git`
+- On `wild diff [args]`: reads git diff, sends to OpenAI (GPT-4), generates an HTML report with a Mermaid.js dependency graph
+- Supports: unstaged, staged (`--staged`), commit ranges, specific files
+- Outputs: HTML report (`diffgraph.html`) auto-opened in browser
+
+**What it does well:** Basic diff → HTML graph pipeline works.
+
+**What it lacks (next iteration targets):**
+- Semantic understanding (it's currently textual diff → LLM summary → Mermaid graph; not true AST/call-graph analysis)
+- Machine-readable output (JSON artifact, not just HTML)
+- Intent capture (no way to attach prompt/task context to a change)
+- Multi-file relationship mapping (each file analyzed somewhat independently)
+- VS Code extension integration
+- Speed (single-threaded, sequential file processing)
+- Model agnosticism (hardcoded OpenAI)
+
+See `docs/Roadmap-v1-git-wrapper.md` for the v1 architecture spec.
+
+---
+
+## The Three Loops (Lifecycle Model)
+
+**Inner loop** — Local development. "What just changed, why, should I continue?"
+- Surfaces: Terminal, CLI, IDE, agent workflows
+- This is where DiffGraph-CLI lives today
+
+**Middle loop** — Collaboration and review. "Can another human responsibly approve this?"
+- Surfaces: GitHub, GitLab, Vibinex, PR comments
+- DiffGraph artifacts should power this eventually
+
+**Outer loop** — Organizational memory. "How has the system evolved, can we trust the process?"
+- Surfaces: Dashboards, audit trails, compliance systems, agent context stores
+- Long-term direction, not near-term focus
+
+**Don't get trapped in the inner loop.** It's the wedge; lifecycle-wide understanding is the larger opportunity.
+
+---
+
+## Design Principles (Distilled)
+
+1. **Evidence over vibes** — Every claim links to code. "This changes auth middleware in auth.ts" not "this improves auth."
+2. **Understanding before automation** — Help users understand and decide first. Earn trust before automating.
+3. **Reduce cognitive load, not agency** — Show the map. Don't make the decision.
+4. **Experienced developers first** — Power tool feel, not tutorial. Fast, accurate, controllable.
+5. **Accuracy > elegance** — A wrong graph is worse than no graph. Ship trustworthy before pretty.
+6. **Latency matters** — This lives in the developer loop. Slow = unused.
+7. **Model agnostic** — Don't couple the core to OpenAI. Static analysis + LLM should complement each other.
+8. **Representation flexible** — Graph is a strong hypothesis, not sacred. Ask "what representation helps this user at this moment?"
+
+---
+
+## Evaluation Criteria (use for every feature decision)
+
+| Dimension | Question | Target |
+|-----------|----------|--------|
+| Problem centrality | Does this attack code-change understanding? | 9+/10 |
+| Developer usefulness | Would an experienced dev use this in a real workflow? | 8+/10 |
+| Accuracy | Are affected components and relationships correct? | 9+/10 |
+| Evidence quality | Can claims be traced to code or metadata? | 8+/10 |
+| Non-commoditization | Is this more than a generic AI summary? | 9+/10 |
+| Latency | Fast enough for the loop it sits in? | 8+/10 |
+
+**If a feature scores low on problem centrality or non-commoditization, treat it skeptically.**
+
+---
+
+## Open Questions (to be explored, not assumed)
+
+1. **Fastest path to repeated usage** — CLI diff? VS Code after AI edits? GitHub PR? CI artifact?
+2. **Best representation** — Graph, tree, sequence, risk-first review path, hybrid? Discover through usage.
+3. **Local vs cloud tradeoff** — Local = privacy + fit; Cloud = collaboration + heavy analysis; Hybrid likely.
+4. **Minimum trustworthy analysis** — Define a narrow trust boundary early. "We reliably identify changed symbols and dependency relationships for TypeScript/Python repos under 100k LOC" beats generic claims.
+5. **Durable memory artifacts** — What should be stored long-term? DiffGraph, intent, risk signals, review decisions, architecture constraints.
+
+---
+
+## Reference Documents
+
+| Doc | What it covers |
+|-----|---------------|
+| `docs/WildestAI-vision.md` | Full 22-section WildestAI handover context (deep reference) |
+| `docs/research/METR-2025-summary.md` | Why AI slows experienced developers on mature codebases |
+| `docs/research/IndiaFOSS-2025-diffs-dont-scale.md` | "Diffs Don't Scale" talk — the public-facing problem statement |
+| `docs/Roadmap-v1-git-wrapper.md` | v1 CLI architecture spec |
+| `docs/Roadmap-v0-initialize.md` | v0 initialization notes |
+| `CHANGELOG.md` | Version history |
+
+---
+
+## Working With This Project
+
+**Before any session:**
+1. Read this file (CONTEXT.md)
+2. Check `CHANGELOG.md` for current version
+3. Look at the relevant roadmap doc for the current milestone
+
+**Before writing any code:**
+- Score the proposed change against the evaluation criteria above
+- If it doesn't attack code-change understanding at 9+/10, stop and ask why we're doing it
+
+**Guiding question for every decision:**
+> *Does this make code changes easier to understand, safer to verify, and easier to trace?*

--- a/docs/WildestAI-vision.md
+++ b/docs/WildestAI-vision.md
@@ -1,0 +1,1722 @@
+WildestAI Handover Context
+1. The durable mission
+
+WildestAI exists to solve a core bottleneck in AI-native software development:
+
+Software teams can now produce code faster than they can understand, verify, align, and safely evolve it.
+
+AI coding tools have dramatically increased the speed of code production. But the rest of the software development loop has not caught up. Developers still need to decide what should be built, understand what changed, verify that the change is correct, review its impact, debug regressions, preserve architectural integrity, and maintain long-term accountability.
+
+The central WildestAI thesis is:
+
+The future bottleneck in software development is not code generation. It is code-change understanding, verification, and traceability.
+
+WildestAI should become the understanding layer for AI-native software development.
+
+That does not mean it must always be a CLI, a VS Code extension, a GitHub extension, a browser extension, a graph visualization, or a code review tool. Those are product forms. The durable problem is deeper:
+
+When software changes, humans and AI agents need a reliable way to understand what changed, why it changed, what it affects, and whether it is safe to continue.
+
+The product should be optimized around that problem, not around preserving any one interface.
+
+2. The problem we are solving
+2.1 The old world: code was expensive to produce
+
+When humans wrote most code manually, teams often spent meaningful time planning before implementation.
+
+Before a developer wrote code, there might be:
+
+Architecture discussions.
+Data-flow discussions.
+API design reviews.
+Tooling decisions.
+Edge-case analysis.
+Team alignment meetings.
+Informal debates about tradeoffs.
+Shared understanding of why a solution was chosen.
+
+This process was not perfect. It was slow, political, and often inefficient. But it had one important side effect:
+
+Many architectural mistakes were caught before code existed.
+
+The cost of writing code forced people to think before implementation. Planning was not merely process overhead; it was a coordination mechanism. It helped teams align on what should be built, how it should fit into the system, and what tradeoffs were acceptable.
+
+2.2 The new world: code is cheap to produce
+
+AI has changed that.
+
+It is now easy to start writing code immediately. A developer can ask an AI coding agent to implement something, and within minutes, the repo has changed.
+
+That creates a new failure mode:
+
+Because implementation is cheap, teams may skip the alignment that used to happen before implementation.
+
+This does not mean old planning rituals should be preserved exactly. Many of them will become obsolete. But the underlying need does not disappear:
+
+Someone or something still needs to understand the system.
+Someone or something still needs to decide whether a change fits the architecture.
+Someone or something still needs to evaluate tradeoffs.
+Someone or something still needs to preserve intent.
+Someone or something still needs to verify that generated code is robust.
+
+The software process will change, but the need for alignment, verification, and system understanding will not.
+
+2.3 The generation-verification gap
+
+AI has accelerated code generation, but verification remains bottlenecked by human understanding.
+
+This creates the generation-verification gap:
+
+AI makes it cheap to produce code, but not automatically cheap to understand whether that code should exist.
+
+The danger is not merely that AI writes buggy code. Humans also write buggy code. The deeper problem is that AI can produce plausible code whose deeper fit is unclear:
+
+It may solve the local task while violating a broader architectural principle.
+It may pass tests while encoding the wrong abstraction.
+It may add complexity instead of changing the right layer.
+It may implement around a symptom instead of fixing the cause.
+It may miss organizational or historical context.
+It may introduce a decision that nobody explicitly made.
+It may generate code that is locally coherent but globally misaligned.
+
+The key insight:
+
+Reading a diff is not the same as understanding a change.
+Understanding a change is not the same as verifying that the change should exist.
+
+WildestAI should help close that gap.
+
+3. Human mistakes and AI mistakes are different
+
+WildestAI should not assume AI coding agents fail in exactly the same way humans fail.
+
+Humans commonly make mistakes such as:
+
+Forgetting edge cases.
+Misunderstanding requirements.
+Making implementation errors.
+Writing messy code under time pressure.
+Carrying over old assumptions.
+Failing to update tests.
+Missing interactions with unfamiliar parts of the codebase.
+
+AI agents can make those mistakes too. But they also have distinct failure modes:
+
+They overfit to the prompt.
+They produce plausible but ungrounded implementations.
+They miss unstated architectural constraints.
+They ignore historical reasons why the code is shaped a certain way.
+They modify files outside the intended scope.
+They satisfy visible tests while missing hidden invariants.
+They hallucinate abstractions, APIs, conventions, or intended behavior.
+They choose locally convenient designs that create long-term complexity.
+They fail to distinguish between “code that compiles” and “code that belongs.”
+They do not naturally carry organizational memory across arbitrary time horizons.
+They may generate large changes before anyone has agreed that the approach is right.
+
+This matters because WildestAI should not merely recreate human code review with AI summaries.
+
+It should be designed around the new failure profile of AI-assisted and AI-generated development.
+
+4. Organizational complexity makes the problem worse
+
+The bigger the organization, the harder this becomes.
+
+Large organizations have more:
+
+Services.
+Repositories.
+Teams.
+Ownership boundaries.
+Legacy systems.
+Compliance constraints.
+Hidden invariants.
+Deployment environments.
+Internal libraries.
+Historical decisions.
+“Do not touch this unless you know why” areas.
+Tribal knowledge.
+Customer-specific behavior.
+Security, privacy, and reliability requirements.
+
+AI coding agents do not automatically have all of this context. Even when they can search code, they may not understand:
+
+Why a strange implementation exists.
+Which team owns a subsystem.
+Which behavior is contractual.
+Which dependency is politically or operationally constrained.
+Which migration path is safe.
+Which customer relies on an undocumented edge case.
+Which tests are meaningful and which are superficial.
+Which previous attempts failed and why.
+
+So the WildestAI problem becomes more valuable as organizational complexity grows.
+
+In a tiny repo, an AI agent may get away with local reasoning. In a serious codebase, local reasoning is not enough.
+
+The larger the system, the more dangerous it is to treat code generation as a local task.
+
+WildestAI should make hidden context, intent, impact, and risk visible at the moment of change.
+
+5. The durable core: what, why, impact
+
+WildestAI should repeatedly return to three questions:
+
+What changed?
+Why did it change this way?
+What is the impact of this change?
+
+These questions are durable across interfaces, tools, roles, and workflows.
+
+5.1 What changed?
+
+Not just:
+
+Which lines changed?
+Which files changed?
+
+But:
+
+Which components changed?
+Which behavior changed?
+Which APIs changed?
+Which data flows changed?
+Which tests changed?
+Which dependencies changed?
+Which assumptions changed?
+5.2 Why did it change this way?
+
+This includes intent and provenance:
+
+What was the original task?
+What prompt or instruction led to the change?
+What decision was made?
+What alternatives were considered?
+What constraint shaped the implementation?
+Was the decision made by a human, an AI agent, or both?
+Was this a quick patch, a planned refactor, or an architectural decision?
+Why was this approach chosen instead of another?
+
+This is increasingly important in AI-native development because agent sessions, prompts, intermediate reasoning, and rejected attempts may otherwise disappear. Entire is an example of this broader direction: it captures agent sessions, prompts, responses, files touched, and reasoning context alongside commits so teams can understand why code changed, not just what changed.
+
+WildestAI should learn from that direction without being constrained by it. Intent capture is important, but intent alone is not enough.
+
+5.3 What is the impact?
+
+Impact includes:
+
+Runtime behavior.
+User-facing behavior.
+API contracts.
+Data correctness.
+Security posture.
+Compliance exposure.
+Performance.
+Reliability.
+Test coverage.
+Deployment risk.
+Maintainability.
+Architectural drift.
+Future agent behavior.
+
+This triad is a strong product spine:
+
+What changed? Why did it change? What will it affect?
+
+Everything else is an implementation detail.
+
+6. The core job-to-be-done
+
+The primary job is:
+
+When code changes, help the relevant human or AI agent quickly build a correct mental model of what changed, why it changed, what it affects, and what needs attention.
+
+Different users express this job differently.
+
+For an individual developer
+
+“I used an AI coding agent. It changed a lot of code. I need to know what it actually did before I continue, accept, revert, commit, or ask for another iteration.”
+
+For a reviewer
+
+“I am looking at a PR. I do not want to manually reconstruct the system impact from raw diffs. I need to understand the meaningful change quickly enough to review responsibly.”
+
+For an engineering lead
+
+“My team is using AI coding tools. I need confidence that productivity gains are real and not being offset by hidden review, debugging, regression, architectural drift, and maintenance costs.”
+
+For an enterprise team
+
+“We need traceability over how code evolves, especially when AI agents are involved. We need to know what changed, why it changed, what was reviewed, what was accepted, and what evidence supports that decision.”
+
+For future AI agents
+
+“I am an agent operating on a codebase. I need structured context about prior changes, intended behavior, affected components, known risks, and human decisions so I can act more safely.”
+
+7. The software process itself may change
+
+WildestAI should not assume today’s software roles and rituals remain fixed.
+
+When code production becomes cheap, the whole software development process may change.
+
+Today’s teams are organized around roles such as:
+
+Product manager.
+Designer.
+Engineer.
+Tech lead.
+Engineering manager.
+Reviewer.
+QA engineer.
+DevOps engineer.
+Security reviewer.
+Architect.
+
+In an AI-native world, some responsibilities may collapse, move, or be redefined.
+
+Possible future roles or responsibilities may include:
+
+AI-agent orchestrator.
+Verification engineer.
+Context curator.
+Change-risk reviewer.
+Agent workflow designer.
+Software evolution auditor.
+System-intent maintainer.
+Human-in-the-loop approval owner.
+Architecture alignment reviewer.
+Agent memory/operator role.
+
+Some current activities may lose value. For example, if verification becomes dramatically easier, some forms of upfront planning may become less important. Teams may prefer to generate multiple possible implementations, compare them, and verify the best one.
+
+But other forms of planning may become more important, especially around:
+
+Intent.
+Constraints.
+Architecture.
+Evaluation criteria.
+Risk boundaries.
+Reversibility.
+Human approval.
+Long-term maintainability.
+
+So WildestAI should not be built around preserving old process rituals.
+
+It should be built around the durable function those rituals served:
+
+Maintaining alignment between what the system should do, what the code actually does, and what the team understands.
+
+8. The mental models the team should carry
+8.1 Generation vs verification
+
+The most important mental model:
+
+AI has made generation cheap. Verification is now the scarce resource.
+
+WildestAI should not compete primarily on “write more code.” It should compete on making generated or changed code understandable, reviewable, traceable, and safely actionable.
+
+Useful distinction:
+
+Activity	Old bottleneck	New bottleneck
+Writing code	High	Lower
+Producing alternatives	High	Lower
+Starting implementation	High	Very low
+Planning before implementation	Common	Often skipped
+Reading diffs	Medium	Very high
+Understanding system impact	High	Higher
+Preserving intent	Medium	Higher
+Trusting generated changes	High	Higher
+Reviewing safely	High	Higher
+Maintaining traceability	Medium	High
+
+WildestAI should attack the right side of the table.
+
+8.2 Code-change understanding, not just code review
+
+Code review is only one moment in the lifecycle. Understanding is needed before, during, and after review.
+
+A change may need to be understood:
+
+Immediately after an AI agent edits files.
+Before staging or committing.
+While comparing branches.
+During PR review.
+While debugging a regression.
+During release preparation.
+During incident response.
+During audits or compliance checks.
+Months later, when someone asks why a behavior exists.
+By another AI agent that needs to continue from prior work.
+
+So the durable category is not merely “AI code review.”
+
+The better category is:
+
+Code-change understanding.
+
+Code review is one important use case inside it.
+
+8.3 The inner-loop, middle-loop, outer-loop model
+
+WildestAI should think across the full software development lifecycle.
+
+Inner loop: local development
+
+This is where the developer is actively building.
+
+Surfaces may include:
+
+Terminal.
+CLI.
+IDE.
+VS Code extension.
+Cursor/Windsurf/Copilot/Codex/Claude Code/Droid-style agent workflows.
+Local Git working tree.
+Staged changes.
+Temporary branches.
+Agent-generated patches.
+
+Core question:
+
+“What just changed, why, and should I continue from here?”
+
+Possible jobs:
+
+Understand AI-generated edits before accepting them.
+Compare working tree against HEAD.
+Compare staged vs unstaged changes.
+Understand multi-file changes quickly.
+Identify risky or surprising changes.
+Ask the AI agent to revise a specific part of the change.
+Navigate from a conceptual node to the exact code range.
+Preserve the intent/context that led to a change.
+Compare multiple generated implementations.
+
+This was the original home of the wild CLI and VS Code extension.
+
+Middle loop: collaboration and review
+
+This is where changes are prepared for others.
+
+Surfaces may include:
+
+GitHub.
+GitLab.
+Bitbucket.
+Vibinex browser extension.
+Pull request comments.
+PR dashboards.
+Review queues.
+Codeowners workflows.
+CI checks.
+Team review rituals.
+
+Core question:
+
+“Can another human understand and responsibly approve this change?”
+
+Possible jobs:
+
+Explain the logical structure of the change.
+Highlight affected components.
+Show dependency or behavior flow.
+Summarize reviewer-relevant risk.
+Connect PR diff to original task, prompt, issue, or agent session.
+Give leads visibility into review burden and AI-generated-change risk.
+Preserve why a PR chose one implementation over another.
+
+This is where Vibinex, GitHub overlays, Chrome extension workflows, PR comments, and hosted/on-prem review integrations matter.
+
+Outer loop: organizational memory, release, audit, and governance
+
+This is where teams need long-term accountability.
+
+Surfaces may include:
+
+Release dashboards.
+Engineering intelligence dashboards.
+Audit trails.
+Compliance systems.
+Security review systems.
+Architecture review systems.
+Incident retrospectives.
+Enterprise data warehouses.
+On-prem deployments.
+Agent memory/context systems.
+
+Core question:
+
+“How has the system evolved, why did it evolve this way, and can we trust the process that produced it?”
+
+Possible jobs:
+
+Trace why a change exists.
+Understand impact across repositories.
+Connect code changes to prompts, tickets, tests, deployments, incidents, and approvals.
+Prove review or verification happened.
+Identify recurring risky patterns.
+Support regulated environments where traceability matters.
+Provide AI agents structured historical context.
+
+The important point:
+
+WildestAI should not be trapped in the inner loop. The inner loop may be the wedge. Lifecycle-wide understanding is the larger opportunity.
+
+8.4 Git as the substrate, not just Git diff as the UI
+
+Git should be treated as a versioned database of software evolution.
+
+The product may start with git diff, but it should not be mentally limited to textual diffs.
+
+Useful Git primitives include:
+
+diff
+log
+blame
+commit
+show
+grep
+ls-tree
+branches
+staged vs unstaged state
+hooks
+merge bases
+commit metadata
+blob storage
+tags and releases
+
+WildestAI should be able to reason about changes across:
+
+Working tree.
+Staged changes.
+Commit ranges.
+Branch comparisons.
+Pull requests.
+Historical changes.
+Cross-repo changes.
+Generated patches from AI agents.
+Agent-session checkpoints.
+Reverted or rejected attempts.
+
+The product should eventually think in terms of:
+
+Code evolution as structured data.
+
+Not merely:
+
+“Pretty diff viewer.”
+
+8.5 Semantic diffing vs textual diffing
+
+A textual diff answers:
+
+“Which lines changed?”
+
+A semantic diff should answer:
+
+“What changed in the system?”
+
+Those are different.
+
+A durable WildestAI system should infer or represent concepts such as:
+
+Functions added, removed, or modified.
+Classes, modules, APIs, endpoints, schemas, migrations, configs, tests, and workflows affected.
+Control flow changes.
+Data flow changes.
+Dependency changes.
+Behavior changes.
+Interface changes.
+Side effects.
+Risk hotspots.
+Test coverage relevance.
+Runtime or deployment implications.
+Security or compliance-sensitive changes.
+Cross-file or cross-service propagation.
+Intent and decision context.
+
+The product does not need to solve all of this perfectly on day one. But the team should keep moving from line-level representation toward system-level understanding.
+
+8.6 DiffGraph as an output language, not necessarily the product itself
+
+DiffGraph is the first major representation WildestAI explored.
+
+The core idea:
+
+Represent a code change as a graph of affected components and relationships so the user can understand the logical structure of the change faster than by reading a raw diff.
+
+A DiffGraph may show:
+
+Changed functions/classes/modules.
+Dependencies between affected components.
+Sequential flow of behavior.
+Caller/callee relationships.
+Data flow.
+Entry points and downstream effects.
+Tests connected to changed code.
+PR-level or branch-level change structure.
+Intent and impact links.
+
+But the team should not be dogmatic about “graph” as the only representation.
+
+The durable goal is:
+
+A better representation of code-change understanding.
+
+That representation might be:
+
+A graph.
+A sequence diagram.
+A dependency map.
+A narrative with linked evidence.
+A risk heatmap.
+A code navigation tree.
+A review checklist.
+A structured JSON artifact.
+A timeline.
+A traceability record.
+A multi-view UI where graph is one mode.
+
+DiffGraph should be treated as a strong starting hypothesis, not as a sacred final form.
+
+9. What WildestAI should help users do
+9.1 Understand what changed
+
+The basic product promise:
+
+“Show me what changed in a way my brain can understand.”
+
+This includes:
+
+Grouping related changes.
+Explaining the purpose of each group.
+Showing affected components.
+Connecting local edits to system behavior.
+Reducing the need to jump manually across files.
+Helping users distinguish meaningful changes from mechanical noise.
+9.2 Understand why it changed
+
+WildestAI should help preserve and recover intent.
+
+This includes:
+
+Original task or prompt.
+Agent session.
+Human instruction.
+Linked issue/ticket.
+PR description.
+Commit message.
+Design constraint.
+Architectural decision.
+Rejected alternatives.
+Review feedback.
+Human approval.
+
+This matters because code without intent becomes harder to maintain, especially when the author was an AI agent and the reasoning disappears after the session ends.
+
+9.3 Understand why it matters
+
+A change is not important merely because many lines changed.
+
+WildestAI should help users identify:
+
+Behaviorally meaningful changes.
+Public API changes.
+Risky dependency changes.
+Authentication, authorization, payment, data, infrastructure, or security changes.
+Changes that affect user-facing behavior.
+Changes that affect tests, deployment, or operations.
+Changes that look unrelated to the stated task.
+Changes that require human attention.
+9.4 Verify AI-generated code
+
+The system should help answer:
+
+Did the AI agent do what was asked?
+Did it choose the right layer of the system?
+Did it modify files outside the intended scope?
+Did it introduce new behavior?
+Did it break existing contracts?
+Did it add tests that actually cover the change?
+Did it make superficial changes to satisfy tests?
+Did it create hidden coupling or tech debt?
+Did it preserve architectural intent?
+Should the user accept, reject, revert, or ask for another iteration?
+
+This is not the same as “AI bug detection.” Bug detection is useful, but insufficient.
+
+The deeper goal is verification support through understanding.
+
+9.5 Make code review faster and safer
+
+WildestAI should help reviewers avoid wasting time reconstructing context from raw diffs.
+
+Potential review support:
+
+PR-level conceptual map.
+Reviewer-specific areas of concern.
+Changed behavior summary with code references.
+Impacted ownership areas.
+Suggested review path.
+“Start here” node for large diffs.
+Files that look mechanically changed vs semantically important.
+Questions the reviewer should ask.
+Generated evidence for claims.
+Links between code, intent, tests, and risk.
+
+The product should avoid false confidence. It should not say “safe” unless there is a defensible basis.
+
+Better wording is often:
+
+“Likely low risk because…”
+“Needs attention because…”
+“This appears unrelated to the stated task…”
+“This change affects authentication flow…”
+“Tests were added, but they do not cover the changed branch…”
+9.6 Preserve traceability
+
+AI-native development creates a traceability problem.
+
+The important history is not just commits. It may include:
+
+Prompt or task that initiated the change.
+Agent used.
+Files touched.
+Intermediate attempts.
+Accepted/rejected changes.
+Human edits after AI generation.
+Tests run.
+Review comments.
+Approval decisions.
+Deployment outcome.
+Later regressions.
+
+WildestAI should eventually help connect these pieces.
+
+The long-term artifact is not just a visualization. It is a structured record of software evolution.
+
+10. Product surfaces imagined so far
+
+These are not constraints. They are starting points and historical context.
+
+10.1 wild CLI
+
+The CLI is the underlying engine and local entry point.
+
+Current/future command family may include:
+
+wild diff
+wild diff --staged
+wild diff <commit-range>
+wild commit
+wild log
+wild blame
+wild explain
+wild review
+wild trace
+wild audit
+
+The CLI should be useful for:
+
+Local developers.
+Power users.
+AI agents.
+IDE extensions.
+CI systems.
+Git hooks.
+Enterprise/on-prem environments.
+Generating structured artifacts for other interfaces.
+
+Important principle:
+
+CLI is not the final UX for everyone. CLI is the portable engine and integration layer.
+
+The CLI should ideally emit machine-readable output in addition to human-readable or HTML output.
+
+Possible outputs:
+
+HTML.
+JSON.
+Markdown.
+Mermaid.
+SARIF-like formats.
+diffgraph.json.
+Review annotations.
+IDE-consumable data.
+CI artifacts.
+Agent-consumable context.
+10.2 VS Code extension
+
+The VS Code extension is a natural inner-loop interface.
+
+Historical product direction included:
+
+Source Control-like sidebar.
+Repositories listed in workspace.
+Changes and staged changes.
+Triggering DiffGraph generation when a node opens.
+Refresh action to regenerate.
+Opening generated graph in a webview.
+Navigation from graph node to exact code range.
+Context menu AI actions.
+Working with local Git state.
+Packaging that avoids fragile local CLI setup.
+Supporting codebases under roughly 100k LOC initially.
+Prioritizing fast shipping and accuracy over architectural perfection.
+
+The extension should help users answer:
+
+“What did this AI agent just do inside my workspace?”
+
+Possible evolution:
+
+Integrate with Cursor/Windsurf/Copilot/Claude Code/Codex-style workflows.
+Detect agent sessions.
+Show change understanding immediately after generation.
+Attach prompts/intents to changes.
+Let users ask targeted follow-up questions about graph nodes.
+Let users send selected graph context back to an AI agent.
+Compare AI attempt A vs AI attempt B.
+Support virtual branches or temporary change sets.
+Support multi-repo workspaces.
+10.3 Vibinex / GitHub / browser extension
+
+Vibinex is relevant as the collaborative review surface.
+
+Historical context:
+
+Vibinex was originally focused on improving code review UX.
+The WildestAI direction can revive Vibinex by using wild/DiffGraph as the understanding engine.
+The browser extension can augment GitHub/Bitbucket/GitLab PR pages.
+Earlier work included GitHub PR comments with Mermaid-style DiffGraph output.
+There was prior feedback from engineers using Vibinex-like workflows.
+
+Potential jobs:
+
+Make PRs easier to understand.
+Add semantic navigation over GitHub diffs.
+Show impact map inside PR UI.
+Provide reviewer-specific summaries.
+Connect PR review to local wild artifacts.
+Help teams review AI-generated PRs.
+Provide traceability from task/prompt to PR to deployment.
+
+Important principle:
+
+Vibinex should not merely be “GitHub plus summaries.” It should become a better interface for understanding software changes.
+
+10.4 CI/CD integration
+
+CI is a natural automation point.
+
+Potential uses:
+
+Generate DiffGraph on PR open/update.
+Comment or attach artifact.
+Flag high-risk changes.
+Detect mismatch between stated PR purpose and changed files.
+Require human review for specific categories of change.
+Produce traceability artifacts.
+Store structured change summaries.
+Feed dashboards.
+
+But CI should be careful not to become noisy.
+
+Bad version:
+
+“AI comments on every PR with generic summaries.”
+
+Good version:
+
+“WildestAI produces a trustworthy, navigable, evidence-linked change understanding artifact that reviewers actually use.”
+
+10.5 Enterprise / on-prem version
+
+Some customers will need strict data rules.
+
+The product should be able to support:
+
+On-prem deployment.
+VPC deployment.
+No code retention.
+Configurable model providers.
+Bring-your-own-model or bring-your-own-key.
+Audit logs.
+Data retention controls.
+Access control.
+Multi-repo indexing.
+Compliance workflows.
+
+This matters especially for finance, healthcare, defense, public companies, and other regulated teams.
+
+But compliance should be understood as an expansion vector, not necessarily the first wedge.
+
+The primary wedge remains developer productivity and AI-code understanding.
+
+10.6 Agent-facing layer
+
+Future AI agents may be direct users.
+
+An agent may need:
+
+Structured representation of current code changes.
+Historical context of prior changes.
+Risk areas.
+Dependency map.
+Review feedback.
+Known invariants.
+Current task intent.
+Human-approved understanding artifact.
+A way to ask: “What part of the system am I touching?”
+
+This means WildestAI should produce artifacts that are useful not only to humans but also to other agents.
+
+The team should think of WildestAI as potentially becoming:
+
+The shared context layer between humans, codebases, and AI coding agents.
+
+11. The product should remain representation-flexible
+
+The team should not overfit to any single UI or artifact.
+
+Do not assume the answer must always be:
+
+A graph.
+A CLI.
+A VS Code extension.
+A GitHub extension.
+A PR comment.
+A code review bot.
+A dashboard.
+A textual summary.
+A particular LLM provider.
+A particular agent framework.
+
+Instead, continuously ask:
+
+“What representation best helps this user understand this change at this moment?”
+
+Examples:
+
+Situation	Possibly best representation
+Small local AI edit	Inline IDE explanation + changed component list
+Large multi-file refactor	Dependency graph + grouped change clusters
+API behavior change	Before/after behavior trace
+Bug fix	Causal path from symptom to changed logic
+PR review	Reviewer-oriented map + risk checklist
+Release review	Timeline + affected systems
+Compliance audit	Evidence-linked traceability record
+AI-agent handoff	Structured JSON context + constraints
+
+The goal is not to force all use cases into one visualization.
+
+The goal is to preserve the user’s ability to reason.
+
+12. Product principles
+12.1 Evidence over vibes
+
+Every claim should ideally be tied to evidence.
+
+Bad:
+
+“This change improves authentication.”
+
+Better:
+
+“This change modifies the authentication middleware in auth.ts, changes token validation behavior in validateSession, and updates two tests covering expired-token handling.”
+
+WildestAI should make it easy to jump from claim to code.
+
+12.2 Understanding before automation
+
+Do not rush to automate decisions that users do not yet trust.
+
+The initial product should help users understand and decide.
+
+Over time, some actions can become automated:
+
+Generate review artifacts.
+Suggest reviewers.
+Flag risk.
+Create checklists.
+Route changes.
+Block clearly unsafe changes.
+
+But the core trust is earned by making reasoning visible.
+
+12.3 Reduce cognitive load, not agency
+
+The product should not replace the developer’s judgment.
+
+It should reduce the work required to exercise judgment.
+
+Good product behavior:
+
+Shows the map.
+Highlights risk.
+Gives evidence.
+Makes navigation easier.
+Preserves uncertainty.
+Lets users inspect the source.
+
+Bad product behavior:
+
+Overconfidently declares safety.
+Hides important details.
+Produces generic summaries.
+Optimizes for looking smart rather than being useful.
+Forces users into a black-box workflow.
+12.4 Optimize for experienced developers first
+
+The strongest early users are likely experienced developers who already understand the pain.
+
+They do not need patronizing explanations of basic code.
+
+They need:
+
+Faster orientation.
+Accurate grouping.
+Better navigation.
+Fewer surprises.
+Evidence-linked analysis.
+Control.
+Low latency.
+Local workflow integration.
+Trustworthy handling of real codebases.
+
+The product should feel like a power tool, not a tutorial.
+
+12.5 Make the invisible structure visible
+
+Raw diffs hide structure.
+
+WildestAI should reveal:
+
+Logical clusters.
+Dependencies.
+Sequences.
+Entry points.
+Side effects.
+Ownership.
+Risk.
+Intent.
+Review path.
+
+This is the core UX philosophy.
+
+12.6 Be model-agnostic where possible
+
+The product should not become unnecessarily dependent on one AI provider.
+
+OpenAI may be used for quality and speed. But the architecture should leave room for:
+
+Anthropic.
+Google.
+Open-source models.
+Local models.
+Customer-provided models.
+Hybrid static + LLM analysis.
+Non-LLM program analysis.
+
+The durable asset should be the workflow, data model, evaluation system, and change-understanding layer — not a thin wrapper over one model.
+
+12.7 Static analysis and LLMs should complement each other
+
+LLMs are useful for semantic interpretation, grouping, naming, and explanation.
+
+But static analysis can provide grounding:
+
+ASTs.
+Call graphs.
+Dependency graphs.
+Import graphs.
+Type information.
+Test mapping.
+Ownership metadata.
+Code search.
+Build/test outputs.
+
+The best system will likely combine deterministic code intelligence with probabilistic reasoning.
+
+12.8 Accuracy matters more than elegance
+
+A beautiful graph that is wrong is worse than useless.
+
+Early versions should prioritize:
+
+Correct affected components.
+Correct relationships.
+Correct navigation.
+Correct grouping.
+Clear uncertainty.
+Fast regeneration.
+Useful failure modes.
+
+Do not over-invest in visual polish before the core analysis is trustworthy.
+
+12.9 Latency matters because this is in the developer loop
+
+If the product sits in the inner loop, slow output kills usage.
+
+The system should support:
+
+Incremental analysis.
+Caching.
+Background generation.
+Progressive rendering.
+Partial results.
+Local indexes.
+Cheap first-pass analysis.
+Deeper analysis on demand.
+
+A product that is occasionally brilliant but usually too slow will lose.
+
+12.10 Do not become a generic AI summary tool
+
+The world will be flooded with “AI summarizes your PR” products.
+
+WildestAI should be different.
+
+The moat should come from:
+
+Code-change representation.
+Git-native workflows.
+Graph/structure orientation.
+Evidence-linked understanding.
+Lifecycle traceability.
+Developer-native UX.
+Multi-surface integration.
+Accumulated change intelligence over time.
+13. The different kinds of understanding WildestAI may provide
+
+A complete system may support several layers of understanding.
+
+13.1 Syntactic understanding
+
+What files, functions, classes, and modules changed?
+
+This is the lowest layer.
+
+13.2 Structural understanding
+
+How are the changed components connected?
+
+Examples:
+
+Function A calls function B.
+Endpoint X now uses service Y.
+Component P passes new prop Q.
+Migration M affects model N.
+13.3 Behavioral understanding
+
+What does the system do differently now?
+
+Examples:
+
+Login now rejects expired tokens earlier.
+Checkout now retries payment failures.
+API response shape includes a new field.
+Background job now skips inactive users.
+13.4 Intent understanding
+
+What was the change trying to accomplish?
+
+Sources:
+
+Prompt.
+Ticket.
+Commit message.
+PR description.
+Branch name.
+Conversation with agent.
+Test names.
+Code comments.
+Human input.
+Prior architectural decision.
+13.5 Decision understanding
+
+Why was this approach chosen?
+
+Examples:
+
+Simpler implementation accepted for speed.
+Existing abstraction reused intentionally.
+Backward compatibility required.
+Data model change avoided because migration risk was high.
+Temporary patch chosen because release was urgent.
+AI-generated approach accepted after human review.
+Alternative rejected because it broke ownership boundaries.
+
+This is distinct from intent. Intent says what the change was trying to accomplish. Decision understanding explains why this specific shape of change exists.
+
+13.6 Risk understanding
+
+What could go wrong?
+
+Examples:
+
+Auth behavior changed.
+Database migration is irreversible.
+Public API contract changed.
+Error handling became broader.
+Tests only cover happy path.
+A config default changed.
+A dependency was upgraded.
+AI modified code outside the prompt scope.
+Change conflicts with prior architecture.
+13.7 Review understanding
+
+Who should look at this, and where should they start?
+
+Examples:
+
+Backend owner should review service changes.
+Security reviewer should inspect auth path.
+Frontend reviewer can ignore generated snapshots.
+Start review at the changed entry point.
+13.8 Historical understanding
+
+How did we get here?
+
+Examples:
+
+This function was changed by three AI-generated PRs in two weeks.
+This behavior was introduced for customer X.
+This regression likely relates to commit Y.
+Similar past change caused incident Z.
+This architecture was chosen because prior approach failed.
+
+The long-term product should climb this ladder.
+
+14. Use cases to support or explore
+14.1 “What did the AI just do?”
+
+A developer asks an agent to make a change. The agent edits several files.
+
+WildestAI should quickly show:
+
+Files touched.
+Logical groups of change.
+Main behavior change.
+Surprising/unrelated edits.
+Test changes.
+Risky areas.
+Suggested next verification step.
+14.2 “Should I accept this generated patch?”
+
+The developer needs help deciding whether to accept, reject, or ask for revisions.
+
+WildestAI should support:
+
+Patch-level understanding.
+Intent-match checking.
+Risk identification.
+Evidence-linked explanation.
+Suggested follow-up prompts to the coding agent.
+Comparison against the original task.
+14.3 “Did this implementation follow the right architecture?”
+
+A team needs to know whether generated code aligns with system design.
+
+WildestAI should help identify:
+
+Whether the right layer changed.
+Whether the change bypassed existing abstractions.
+Whether new dependencies are appropriate.
+Whether data flow matches intended architecture.
+Whether generated code created avoidable coupling.
+Whether a design discussion is needed before proceeding.
+14.4 “Review this PR faster”
+
+A reviewer opens a PR.
+
+WildestAI should show:
+
+Conceptual map.
+Important nodes.
+Review path.
+Risk checklist.
+Linked code ranges.
+Test relevance.
+Potential missing coverage.
+Areas safe to skim.
+14.5 “Explain this change to a teammate”
+
+A developer needs to communicate a change.
+
+WildestAI should produce:
+
+Human-readable explanation.
+Architecture-level summary.
+Before/after behavior.
+Impacted components.
+Links to evidence.
+Intent and decision context.
+14.6 “Trace a regression”
+
+Something broke after a change.
+
+WildestAI should help identify:
+
+Relevant recent changes.
+Affected paths.
+Suspect commits.
+Behavior changes.
+Tests that should have caught it.
+Code ownership context.
+Whether an AI-generated change introduced the regression.
+14.7 “Prepare for release”
+
+Before release, the team needs to understand accumulated change.
+
+WildestAI should provide:
+
+Change map across commits/PRs.
+Risk areas.
+User-facing behavior changes.
+Migration/config/dependency changes.
+Test and review coverage.
+Traceability to tickets or prompts.
+14.8 “Audit AI-generated code”
+
+An organization needs accountability.
+
+WildestAI should track:
+
+Which changes involved AI.
+What prompt/task generated them.
+Human review evidence.
+Test evidence.
+Approval trail.
+Risk classification.
+Deployment linkage.
+14.9 “Give an AI agent better context”
+
+An agent needs to continue work safely.
+
+WildestAI should provide:
+
+Structured current-change context.
+Relevant prior change history.
+Affected components.
+Constraints and invariants.
+Known risks.
+Human-approved understanding artifacts.
+15. What should be built as reusable infrastructure
+
+Even if UIs change, certain primitives will stay useful.
+
+15.1 Change ingestion
+
+The system needs to ingest changes from:
+
+Local Git working tree.
+Staged changes.
+Commit ranges.
+Branch comparisons.
+Pull requests.
+Patches.
+Agent sessions.
+CI artifacts.
+Multi-repo contexts.
+15.2 Intent and provenance ingestion
+
+The system should ingest or link to:
+
+Prompts.
+Agent transcripts.
+Tool calls.
+Issues/tickets.
+PR descriptions.
+Commit messages.
+Design docs.
+Human comments.
+Review decisions.
+Previous generated attempts.
+Accepted/rejected alternatives.
+
+This is where tools like Entire are directionally relevant: they show that intent and agent-session history are becoming first-class development artifacts, not side notes.
+
+15.3 Codebase indexing
+
+Useful indexes may include:
+
+Files and symbols.
+Imports and dependencies.
+Call graph.
+Type graph.
+Test mapping.
+Ownership.
+Historical change frequency.
+Runtime/deployment metadata.
+Documentation references.
+Architectural boundaries.
+Known invariants.
+15.4 Change representation
+
+The system should maintain a structured internal representation of a change.
+
+Potential entities:
+
+ChangeSet.
+FileChange.
+SymbolChange.
+Component.
+Relationship.
+BehaviorChange.
+RiskSignal.
+Evidence.
+TestImpact.
+ReviewSuggestion.
+Intent.
+Decision.
+AgentSession.
+HumanDecision.
+TraceabilityLink.
+AlternativeAttempt.
+ArchitecturalConstraint.
+
+This representation should be more durable than any one UI.
+
+15.5 Analysis pipeline
+
+Possible analysis stages:
+
+Parse raw diff.
+Identify changed symbols/components.
+Build dependency context.
+Ingest intent/provenance.
+Group related changes.
+Infer behavior changes.
+Match change against intent.
+Identify architectural implications.
+Identify risk.
+Link tests.
+Generate representations.
+Produce human and machine outputs.
+Store traceability artifacts.
+15.6 Output adapters
+
+The same core analysis should be adaptable to:
+
+CLI output.
+HTML graph.
+JSON artifact.
+VS Code webview.
+GitHub/Bitbucket/GitLab extension.
+PR comment.
+CI report.
+API response.
+Enterprise dashboard.
+Agent context file.
+16. UX principles for each surface
+16.1 CLI UX
+
+Should be:
+
+Fast.
+Scriptable.
+Local-first where possible.
+Useful in terminal-native workflows.
+Capable of producing files for other tools.
+Friendly to agents and automation.
+
+The CLI should avoid becoming an overloaded chatbot. Its strength is composability.
+
+16.2 IDE UX
+
+Should be:
+
+Close to where code is edited.
+Integrated with Git state.
+Navigable to exact code ranges.
+Incremental and responsive.
+Useful after AI agent edits.
+Minimal enough not to distract.
+Powerful enough for deep inspection.
+
+The IDE should answer “what changed?” before the developer loses context.
+
+16.3 PR/browser UX
+
+Should be:
+
+Review-oriented.
+Evidence-linked.
+Collaborative.
+A complement to raw diffs, not a replacement users cannot escape.
+Good at guiding attention.
+Good at summarizing meaningful structure.
+Low-noise.
+
+The reviewer should feel faster and more responsible, not merely entertained by an AI summary.
+
+16.4 Dashboard UX
+
+Should be:
+
+Aggregate.
+Trend-aware.
+Useful for leads.
+Focused on bottlenecks, risk, and traceability.
+Not vanity analytics.
+
+Avoid dashboards unless they drive real decisions.
+
+16.5 Agent UX
+
+Should be:
+
+Structured.
+Machine-readable.
+Compact.
+Explicit about uncertainty.
+Linked to evidence.
+Easy to feed into agent workflows.
+
+Agents do not need beautiful graphs. They need reliable context.
+
+17. What not to build blindly
+17.1 Do not build “AI PR summary” as the whole product
+
+That market will commoditize quickly.
+
+Summaries are a feature. Understanding is the product.
+
+17.2 Do not optimize for demo graphs over real correctness
+
+A visually impressive graph is not valuable if experienced developers cannot trust it.
+
+17.3 Do not overfit to one AI coding tool
+
+Cursor, Windsurf, Claude Code, Codex, Copilot, Droid, and others will evolve. Some will disappear. New ones will emerge.
+
+WildestAI should integrate where useful, but the durable layer is independent:
+
+Code changed. Someone or something needs to understand it.
+
+17.4 Do not assume the human always starts from the PR
+
+In AI-native development, important understanding often needs to happen before commit and before PR.
+
+17.5 Do not hide uncertainty
+
+If the system is unsure, say so.
+
+Trust is built by calibrated confidence, not by fake certainty.
+
+17.6 Do not force one universal workflow
+
+Different teams work differently:
+
+Some are terminal-heavy.
+Some live in VS Code.
+Some live in GitHub.
+Some require on-prem.
+Some use trunk-based development.
+Some use PR-heavy processes.
+Some use AI agents locally.
+Some use cloud agents.
+
+Build primitives that survive workflow diversity.
+
+17.7 Do not blindly preserve old software rituals
+
+Some old rituals existed because code was expensive to produce.
+
+If code becomes cheap and verification becomes easier, some planning and review rituals may disappear or mutate.
+
+The goal is not to preserve old roles.
+
+The goal is to preserve and improve the underlying functions:
+
+Alignment.
+Understanding.
+Verification.
+Accountability.
+System integrity.
+Learning over time.
+18. Strategic positioning
+
+WildestAI can be described in several ways depending on audience.
+
+Developer-facing
+
+WildestAI helps developers understand AI-generated code changes before they accept, review, or ship them.
+
+Engineering team-facing
+
+WildestAI gives teams a better interface for understanding software changes across local development, code review, and release.
+
+AI-native development-facing
+
+WildestAI is the understanding and traceability layer for AI-native software development.
+
+Long-term category
+
+WildestAI is building the standard of record for how software evolves in the age of AI.
+
+Avoid overclaiming
+
+Avoid saying:
+
+“We automate code review.”
+“We guarantee AI code is safe.”
+“We replace developers.”
+“We detect all bugs.”
+“We summarize PRs.”
+
+Prefer:
+
+“We make code changes easier to understand.”
+“We help developers verify AI-generated code.”
+“We reveal the structure, intent, and impact of changes.”
+“We preserve traceability across the development lifecycle.”
+19. Evaluation criteria
+
+The team should evaluate product decisions against these dimensions.
+
+Dimension	Question	Score target
+Problem centrality	Does this attack code-change understanding, or is it peripheral?	9+/10
+Developer usefulness	Would an experienced developer use this in a real workflow?	8+/10
+Accuracy	Are affected components and relationships correct?	9+/10
+Evidence quality	Can claims be traced to code or metadata?	8+/10
+Intent quality	Does it preserve or recover why the change exists?	8+/10
+Impact quality	Does it identify meaningful downstream implications?	8+/10
+Latency	Is it fast enough for the loop it sits in?	8+/10
+Workflow fit	Does it meet users where they already work?	8+/10
+Representation quality	Does the UI reduce cognitive load?	8+/10
+Model independence	Can the system survive provider changes?	7+/10
+Traceability	Does it create durable context for future humans/agents?	8+/10
+Non-commoditization	Is this more than a generic AI summary?	9+/10
+
+A feature that scores low on problem centrality or non-commoditization should be treated skeptically.
+
+20. The most important open questions
+
+The AI agent team should explore these rather than assume fixed answers.
+
+20.1 What is the fastest path to repeated usage?
+
+Is the strongest wedge:
+
+Local wild diff?
+VS Code after AI edits?
+GitHub PR review?
+Vibinex browser extension?
+CI-generated PR artifact?
+Agent-to-agent context?
+Enterprise traceability?
+
+The answer may change with the market.
+
+20.2 What representation actually helps developers most?
+
+Possibilities:
+
+Graph.
+Tree.
+Sequence view.
+Layered summary.
+Risk-first review path.
+Code navigation overlay.
+Hybrid view.
+
+The right answer should be discovered through usage, not ideology.
+
+20.3 How much should be local vs cloud?
+
+Tradeoffs:
+
+Local improves privacy and workflow fit.
+Cloud improves collaboration and heavy analysis.
+Enterprise may require on-prem.
+Hybrid may be necessary.
+20.4 What is the minimum trustworthy analysis?
+
+The system does not need to understand everything. But it must be trusted for what it claims.
+
+The team should define a narrow trust boundary early.
+
+Example:
+
+“We reliably identify changed symbols, dependency relationships, and likely review hotspots for TypeScript/Python repos under 100k LOC.”
+
+That is better than broad generic claims.
+
+20.5 What should be stored as durable memory?
+
+Potential durable artifacts:
+
+DiffGraph.
+Intent.
+Prompt.
+Change summary.
+Risk signals.
+Test evidence.
+Review decisions.
+Human comments.
+Agent session metadata.
+Final accepted explanation.
+Rejected alternatives.
+Architecture constraints.
+Human-approved rationale.
+
+This matters for traceability and future agent context.
+
+20.6 How does planning evolve when verification becomes easier?
+
+This is a major strategic question.
+
+If verification becomes cheap enough, teams may shift from:
+
+“Plan extensively, then implement once.”
+
+Toward:
+
+“Generate multiple implementation paths, compare them, verify impact, and choose.”
+
+But this only works if verification, comparison, and impact analysis become strong enough.
+
+WildestAI may therefore reduce the need for some kinds of planning while increasing the importance of explicit intent, constraints, and evaluation criteria.
+
+21. Suggested initial operating focus
+
+The AI agent team should not try to build the entire vision at once.
+
+A strong near-term focus:
+
+Make wild diff and the VS Code extension extremely useful for understanding AI-generated local changes, while designing the core representation so it can later power Vibinex/GitHub, CI, agent context, and enterprise traceability.
+
+This means:
+
+Build a reliable change ingestion layer.
+Produce a structured change representation.
+Generate an understandable visual or navigable view.
+Link every claim to code evidence.
+Capture or connect intent where available.
+Identify impact and risk.
+Make local workflows fast.
+Expose machine-readable artifacts.
+Keep output adapters separate from core analysis.
+Use real developer feedback to decide which UI survives.
+
+The immediate product can be narrow. The architecture should not be narrow-minded.
+
+22. A durable north star
+
+The team should keep returning to this:
+
+Every time software changes, WildestAI should make that change easier to understand, safer to verify, and easier to trace.
+
+Or more sharply:
+
+WildestAI turns code changes from raw diffs into understandable, evidence-linked software evolution.
+
+The durable triad:
+
+What changed?
+Why did it change?
+What is the impact?
+
+Everything else — CLI, VS Code, Vibinex, GitHub, Chrome extension, CI, dashboards, graphs, agents — is a surface or strategy in service of that mission.

--- a/docs/research/IndiaFOSS-2025-diffs-dont-scale.md
+++ b/docs/research/IndiaFOSS-2025-diffs-dont-scale.md
@@ -1,0 +1,57 @@
+# "Diffs Don't Scale" — IndiaFOSS 2025 Talk
+
+**Talk by:** Avikalp Kumar Gupta
+**Conference:** IndiaFOSS / FOSS United 2025
+**Full script:** See original PDF (IndiaFOSS_2025_script.pdf)
+
+---
+
+## The Narrative Arc
+
+### Personal hook
+In 2019, a CTO told Avikalp the path to leadership was through PR reviews. It worked. He's been obsessed with code review ever since — leading to Vibinex (a company dedicated to making PR reviews better).
+
+### The shift
+After 2 years and hundreds of users at Vibinex, AI coding tools started changing the game. Teams started generating more code, faster — but something was off.
+
+### The problem
+Sundar Pichai's own data is the irony: 30% of Google's new code is AI-generated, yet development teams are only 10% more productive. METR found AI *reduced* delivery speed by 19%.
+
+Why? Because **AI changed the workflow**. Developers went from "author" to "prompter." They no longer have an innate understanding of the code they ship.
+
+### Karpathy's loop
+Andrej Karpathy described it best: any AI interaction is a generation ↔ verification loop. Generation got fast. Verification (which means reading the diff) is still slow.
+
+### The thesis
+**Diffs don't scale.**
+
+Traditional git diffs worked when humans wrote small, deliberate changes. They break when AI generates thousands of lines in minutes. Verifying a huge AI-generated diff manually can take hours — only to find it's wrong, or the approach is entirely off. After that effort, will you prompt AI to fix it? Probably not. You'll take the boilerplate and fix it yourself, or git reset and start over.
+
+### The compounding problem
+It's not just one developer. Multiple people verify the same change. And the *same* diff interface appears everywhere:
+- `git diff` in terminal
+- Diff view in VS Code
+- GitHub PR
+- Git blame while debugging
+
+**The diff is unavoidable. But it doesn't scale.**
+
+---
+
+## Key Points for DiffGraph-CLI Context
+
+1. **This is Avikalp's lived experience** — the talk is autobiographical, not academic. The problem is real and personal.
+
+2. **The framing is public** — this is how the problem will be explained to developers at conferences. DiffGraph-CLI should deliver on this promise.
+
+3. **The METR data is key evidence** — it's called out explicitly in the talk. The empirical grounding matters.
+
+4. **Verification can't be fully automated** — the talk sets up (beyond the script excerpt we have) that "just use AI to verify" doesn't work. You still need a human understanding the change.
+
+5. **The opportunity:** A tool that makes the diff *comprehensible* — that turns raw line-level noise into structured, semantic, navigable change understanding — directly addresses the problem this talk describes.
+
+---
+
+## Elevator Pitch (from this talk)
+
+> AI made code generation cheap. But we still review changes the same way we did in 1990 — by reading a wall of plus and minus signs. DiffGraph makes the invisible structure of your code changes visible, so you can understand what AI actually did in seconds, not hours.

--- a/docs/research/METR-2025-summary.md
+++ b/docs/research/METR-2025-summary.md
@@ -1,0 +1,53 @@
+# METR 2025: Impact of AI on OSS Developer Productivity
+
+**Source:** "Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity" (METR, 2025)
+
+## Headline Finding
+
+Experienced open-source developers using early-2025 AI tools were **19% slower** on average — not faster.
+
+This contradicted all prior estimates:
+- Economics experts forecast: **+39% speedup**
+- ML experts forecast: **+38% speedup**
+- Developer self-forecast (before task): **+24% speedup**
+- Developer self-report (after task): still believed **+20% speedup**
+
+The gap between perceived and actual impact is itself a key finding: developers couldn't detect the slowdown even after experiencing it.
+
+## Methodology
+
+- Randomized controlled trial: 16 experienced developers, 246 real tasks
+- Tasks averaged 2 hours on mature, popular repos (avg. 23k stars, 1.1M LOC, 10 years old)
+- Developers averaged 5 years experience, 1,500 commits on their repo
+- Tasks were defined *before* randomization (avoiding AI changing task scope)
+- Primary outcome: actual wall-clock completion time
+- Supporting data: 143 hours of manually labeled screen recordings, exit interviews, Cursor analytics
+- AI tool used: Cursor Pro with Claude 3.5/3.7 Sonnet
+
+## What Explains the Slowdown? (Top 5 Factors)
+
+1. **Over-optimism about AI usefulness** — Developers used AI even when counterproductive
+2. **High developer familiarity** — On tasks they knew well, AI couldn't outperform deep expertise
+3. **Large, complex repos** — AI performed worse in mature, sprawling codebases vs. greenfield
+4. **Low AI reliability** — <44% of suggestions accepted; 9% of total time spent reviewing/cleaning AI outputs
+5. **Implicit repo context** — AI lacked the tacit knowledge (conventions, edge cases, design decisions) experienced contributors rely on
+
+## What Ruled Out
+
+- Not from avoiding AI (used in ~84% of allowed cases)
+- Not from Cursor unfamiliarity (similar for experienced Cursor users)
+- Not from weak models (mostly Claude 3.5/3.7 Sonnet)
+- Not from outcome measure choice (robust to alternatives)
+
+## Relevance to WildestAI / DiffGraph-CLI
+
+This study validates the core WildestAI thesis in two ways:
+
+**1. Verification is the bottleneck.** The screen recordings showed developers spending *less* time coding and reading with AI, but *more* time prompting, waiting, reviewing AI code, and being idle. The generation got faster; the understanding did not. That's exactly the generation-verification gap.
+
+**2. Organizational context matters most.** AI failed hardest where developers had the deepest contextual knowledge — mature codebases with tribal knowledge, architectural constraints, and implicit contracts. This is precisely where DiffGraph-CLI needs to help: making that hidden context visible at the moment of change.
+
+**Quote to keep in mind:**
+> "Developers accepted less than 44% of AI suggestions, and 9% of total time was spent reviewing and cleaning up AI outputs."
+
+That 9% overhead is recoverable — if the verification step becomes significantly cheaper.


### PR DESCRIPTION
## What this does

Adds the project context layer that should be read at the start of every working session on this codebase.

### Files added

**`CONTEXT.md`** (root) — The primary guiding document. Covers:
- North star and the durable triad (what/why/impact)
- The problem being solved + why AI makes it worse
- What this project is NOT
- Current CLI state (v1.0) and what it lacks
- The three loops model (inner/middle/outer)
- Design principles (distilled to 8 key ones)
- Evaluation criteria for every feature decision
- Open questions to explore
- Reference index

**`docs/WildestAI-vision.md`** — Full 22-section WildestAI handover context (the source document reviewed by Avikalp, preserved in full for deep reference).

**`docs/research/METR-2025-summary.md`** — Key findings from the METR 2025 study on AI's impact on OSS developer productivity. Empirical grounding for the verification bottleneck thesis.

**`docs/research/IndiaFOSS-2025-diffs-dont-scale.md`** — Summary of the 'Diffs Don't Scale' talk narrative and its implications for DiffGraph-CLI.

## Why

Before starting any implementation work, the project needs a persistent, structured context layer so that every working session (human or AI agent) starts aligned with the vision rather than drifting into whatever feels locally useful.

## No code changes — docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project context guide with design principles, evaluation criteria, and contributor guidance for the development lifecycle.
  * Added comprehensive vision documentation outlining the project's mission, core problems to solve, and planned product surfaces.
  * Added research materials including conference talk script and developer productivity study findings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WildestAI/DiffGraph-CLI/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->